### PR TITLE
Ezpand and collapse functionality when user clicks a result

### DIFF
--- a/frontend/general.js
+++ b/frontend/general.js
@@ -15,14 +15,20 @@ export async function processSearch(query,resultContainer) {
     })
     const resultElement = element;
     async function onClick() {
-        await onResultClick(firstResult.path,resultElement,query);
+        await onResultClick(firstResult,resultElement,query);
     }
 }
 
-async function onResultClick(resultPath,resultDiv,searchedWord) {
-    const result = await loadResult(resultPath);
-    const formattedText = formatTextForResult(result.text,searchedWord)
-    ResultsUI.populateWith({ resultDiv,htmlText: formattedText })
+async function onResultClick(indexedResult,resultDiv,searchedWord) {
+    if (!ResultsUI.isExpanded({ resultDiv })) {
+        const result = await loadResult(indexedResult.path);
+        const formattedText = formatTextForResult(result.text,searchedWord)
+        ResultsUI.populateWith({ resultDiv,htmlText: formattedText })
+        ResultsUI.expand({ resultDiv })
+    } else {
+        ResultsUI.populateWith({ resultDiv,text: indexedResult.title })
+        ResultsUI.collapse({ resultDiv })
+    }
 }
 const N_CHARS_CUT_TEXT = 20
 function formatTextForResult(text,searchedWord) {

--- a/frontend/general.spec.js
+++ b/frontend/general.spec.js
@@ -15,6 +15,18 @@ jest.mock('./EL.js',() => {
     }
 });
 
+function simulateHtmlAttributes(element) {
+    element.mockAttrList = {}
+    element.getAttribute = function (attrName) {
+        return this.mockAttrList[attrName]
+    }
+    element.setAttribute = function (attrName,value) {
+        this.mockAttrList[attrName] = value
+    }
+    element.removeAttribute = function (attrName) {
+        this.mockAttrList[attrName] = undefined
+    }
+}
 
 const mockContainer = { appendChild: jest.fn() }
 
@@ -49,6 +61,7 @@ describe('processSearch',() => {
         const mockedDiv = {
             getElementsByTagName: jest.fn().mockReturnValue([mockedInnerSpan])
         }
+        simulateHtmlAttributes(mockedDiv)
         EL.div.mockReturnValue(mockedDiv)
         EL.span.mockReturnValue(mockedInnerSpan)
     });

--- a/frontend/results/results-ui.js
+++ b/frontend/results/results-ui.js
@@ -1,5 +1,7 @@
 import EL from '../EL.js'
 
+const EXPANDED_DATA_ATTRIBUTE = 'data-expanded';
+
 export function addElements(div,{ resultTitle,onclick }) {
     const element = EL.div({
         els: [
@@ -22,8 +24,27 @@ export function addElements(div,{ resultTitle,onclick }) {
 }
 
 
-export function populateWith({ resultDiv,htmlText }) {
+export function populateWith({ resultDiv,htmlText,text }) {
     let span = resultDiv.getElementsByTagName('span');
     span = span[0];
-    span.innerHTML = htmlText;
+    if (htmlText) {
+        span.innerHTML = htmlText;
+    } else if (text) {
+        span.innerText = text;
+    }
+}
+
+export function isExpanded({ resultDiv }) {
+    if (resultDiv.getAttribute(EXPANDED_DATA_ATTRIBUTE))
+        return true
+    else
+        return false
+}
+
+export function expand({ resultDiv }) {
+    resultDiv.setAttribute(EXPANDED_DATA_ATTRIBUTE,"expanded")
+}
+
+export function collapse({ resultDiv }) {
+    resultDiv.removeAttribute(EXPANDED_DATA_ATTRIBUTE)
 }

--- a/stories/result_one_word_one_file/show_results.md
+++ b/stories/result_one_word_one_file/show_results.md
@@ -18,15 +18,13 @@ When I click on one of the results
 I want to see the text where the result is
 And I want the word i searched for to be highlighted
 
-[in progress]
+[done]
 AC3
 Given I searched for the hardcoded word
 And I click on one of the results
 When I click again on the result
 I want the result to collapse
 And clicking again will show the content again(the cnntent not duplicated)
-- test click again shows title(innerText)
-- test clicking 3 times shows content(innerHtml)
 
 
 AC5


### PR DESCRIPTION
When a user clicks on a result after it already got expanded it will collapse showing just the title of the result, and if it gets clicked again it will expand again.