### PR TITLE
remove old results before adding new results

### DIFF
--- a/frontend/general.js
+++ b/frontend/general.js
@@ -6,15 +6,17 @@ import { shortenText } from './helpers.js'
 
 
 export async function processSearch(query,resultContainer) {
+    ResultsUI.clear(resultContainer)
     const res = await search(query);
     const firstResult = res.results[0]
 
-    const { element } = ResultsUI.addElements(resultContainer,{
+    ResultsUI.addElements(resultContainer,{
         resultTitle: firstResult.title,
         onclick: onClick
     })
-    const resultElement = element;
-    async function onClick() {
+    async function onClick(event) {
+        // Is important to reference the result element from the event, because otherwise we might create a memory leak
+        const resultElement = event.currentTarget;
         await onResultClick(firstResult,resultElement,query);
     }
 }

--- a/frontend/results/results-ui.js
+++ b/frontend/results/results-ui.js
@@ -34,6 +34,10 @@ export function populateWith({ resultDiv,htmlText,text }) {
     }
 }
 
+export function clear(div) {
+    div.replaceChildren()
+}
+
 export function isExpanded({ resultDiv }) {
     if (resultDiv.getAttribute(EXPANDED_DATA_ATTRIBUTE))
         return true

--- a/stories/result_one_word_one_file/show_results.md
+++ b/stories/result_one_word_one_file/show_results.md
@@ -26,18 +26,19 @@ When I click again on the result
 I want the result to collapse
 And clicking again will show the content again(the cnntent not duplicated)
 
-
-AC5
+[done]
+AC4
 Given I searched for the hardcoded word
 When I search for it again
 I want to see just the new results and the old result should disappear
 
-AC6
+
+AC5
 Given the network is not working
 When I run a search
 I want to be informed that something gone wrong
 And the page to still work
 
 [in progress]
-AC7
+AC6
 We want to be able to test the logic in the web application without needing to spin up a browser


### PR DESCRIPTION
Clear the old results before fetching and displaying the new results
Also used `event.currentTarget` in event handler in order to avoid memory leaks that were happening otherwise
(the removed divs weren't cleared but were kept in memory)