### PR TITLE
Fix bug for when there are just 2 results in a page

### DIFF
--- a/frontend/src/helpers.js
+++ b/frontend/src/helpers.js
@@ -135,6 +135,7 @@ export function findClosestGroupOfNumbersOfSize(orderedNumbers,groupLength) {
     if (nConsecutiveNumbersForDifference == null) {
         nConsecutiveNumbersForDifference = orderedNumbers.length - 1
     }
+
     const distances = calculateDifferenceBetweenNConsecutiveNumbers(orderedNumbers,nConsecutiveNumbersForDifference)
 
     const smallerDistance = Math.min(...distances)
@@ -145,10 +146,15 @@ export function findClosestGroupOfNumbersOfSize(orderedNumbers,groupLength) {
 }
 
 export function findBiggerGroupOfNumbersWithinDistance(orderedNumbers,maximumDistance) {
-    const maximumGroupSize = orderedNumbers.length - 1
-    let maximumValidGroupSize = -1
-    let groupStartIdxOfBiggestValidGroup = -1
-    let groupEndIdxOfBiggestValidGroup = -1
+    if (orderedNumbers.length < 2)
+        throw "Invalid parameters, list of number must contain at least 2 numbers"
+
+    const maximumGroupSize = orderedNumbers.length
+    // It defaults to a group with only 1 number, the first
+    let maximumValidGroupSize = 1
+    let groupStartIdxOfBiggestValidGroup = 0
+    let groupEndIdxOfBiggestValidGroup = 0
+
     for (let groupSize = 2; groupSize <= maximumGroupSize; groupSize++) {
         let { groupStartIdx } = findClosestGroupOfNumbersOfSize(orderedNumbers,groupSize)
         let groupEndIdx = groupStartIdx + groupSize - 1
@@ -161,9 +167,7 @@ export function findBiggerGroupOfNumbersWithinDistance(orderedNumbers,maximumDis
             groupEndIdxOfBiggestValidGroup = groupEndIdx
         }
     }
-    if (groupStartIdxOfBiggestValidGroup < 0 || groupEndIdxOfBiggestValidGroup < 0) {
-        throw "No Group Found"
-    }
+
     return {
         groupStartIdx: groupStartIdxOfBiggestValidGroup,
         groupEndIdx: groupEndIdxOfBiggestValidGroup

--- a/frontend/src/helpers.spec.js
+++ b/frontend/src/helpers.spec.js
@@ -94,6 +94,17 @@ describe('findClosestGroupOfNumbersOfSize',() => {
     })
 
     it.each([
+        [[2,6,8,10],2],
+        [[2,11,20,22],2],
+        [[12,13,18,19],12],
+    ])('returns first number if the group size is the same as the group',(numbers,expectedFirstNumberOfGroup) => {
+        const result = findClosestGroupOfNumbersOfSize(numbers,4)
+        const actualFirstNumber = numbers[result.groupStartIdx]
+
+        expect(actualFirstNumber).toBe(expectedFirstNumberOfGroup)
+    })
+
+    it.each([
         [[2,6,8,10,20],2],
         [[2,3,8,12,55],2],
         [[1,23,25,30,31],23],
@@ -153,13 +164,47 @@ describe('findBiggerGroupOfNumbersWithinDistance',() => {
         expect(actualLastNumber).toBe(expectedLastNumberOfGroup)
     })
 
-    it('return the end of the group found',() => {
+    it('returns the end of the group found',() => {
         const numbers = [2,6,8,12]
         const expectedLastNumber = 8
         const result = findBiggerGroupOfNumbersWithinDistance(numbers,3)
         const actualLastNumber = numbers[result.groupEndIdx]
 
         expect(actualLastNumber).toBe(expectedLastNumber)
+    })
+
+    it('returns a goup with just 1 number if all the other numbers are too far away',() => {
+        const numbers = [2,6,10,14,18]
+        const expectedFirstNumberOfGroup = 2
+        const expectedLastNumberOfGroup = 2
+        const result = findBiggerGroupOfNumbersWithinDistance(numbers,3)
+        const actualFirstNumber = numbers[result.groupStartIdx]
+        const actualLastNumber = numbers[result.groupEndIdx]
+
+        expect(actualFirstNumber).toBe(expectedFirstNumberOfGroup)
+        expect(actualLastNumber).toBe(expectedLastNumberOfGroup)
+    })
+
+    it('selects all the numbers if all of them are within the distance',() => {
+        const numbers = [2,6,10,14,18]
+        const expectedFirstNumberOfGroup = 2
+        const expectedLastNumberOfGroup = 18
+        const result = findBiggerGroupOfNumbersWithinDistance(numbers,20)
+        const actualFirstNumber = numbers[result.groupStartIdx]
+        const actualLastNumber = numbers[result.groupEndIdx]
+
+        expect(actualFirstNumber).toBe(expectedFirstNumberOfGroup)
+        expect(actualLastNumber).toBe(expectedLastNumberOfGroup)
+    })
+
+    it('supports a list of 2 numbers',() => {
+        const numbers = [2,6]
+        const result = findBiggerGroupOfNumbersWithinDistance(numbers,10)
+        const actualFirstNumber = numbers[result.groupStartIdx]
+        const actualLastNumber = numbers[result.groupEndIdx]
+
+        expect(actualFirstNumber).toBe(2)
+        expect(actualLastNumber).toBe(6)
     })
 
     it('errors if something goes wrong',() => {

--- a/frontend/src/results/contentFormatters/formatterHelpers.spec.js
+++ b/frontend/src/results/contentFormatters/formatterHelpers.spec.js
@@ -103,6 +103,17 @@ describe('getSectionWithMostNumberOfResultsUnprecise',() => {
         expect(actualStringExtracted).toContain('word')
     })
 
+    it('works even when there are just two results',() => {
+        const text = 'test test test word test word'
+        const searchedWord = 'word'
+        const sectionLength = 20
+
+        const { sectionStartIdx,sectionEndIdx } = getSectionWithMostNumberOfResultsUnprecise(text,[searchedWord],sectionLength)
+        const actualStringExtracted = extractString(text,sectionStartIdx,sectionEndIdx)
+
+        expect(actualStringExtracted).toContain('word test word')
+    })
+
     it('returns the right length of a section even when the found word is at the end',() => {
         const text = 'test test test test word'
         const searchedWord = 'word'

--- a/users_and_roadmap.md
+++ b/users_and_roadmap.md
@@ -84,7 +84,7 @@ So that I can decide if to use it, and know how to use it
 ### ~~fix packages vulnerabilities~~
 Check vulnerabilities from packages and use version of the packages that are not affected
 
-### Fix big with file containing 2 words
+### ~~Fix bug with file containing 2 words~~
 Given a file contains a word exactly 2 times
 When I'm searching for that word
 I want to be able to see the preview of the file correctly


### PR DESCRIPTION
Fix bug when there are just 2 results in a page.

Also made `findBiggerGroupOfNumbersWithinDistance` support the scenario when there is just 1 result within the range.
I think this means that there was another bug when in the page there were multiple results, but they were all 150 characters away from each other. Now this scenario should be supported, it will select the first result and get the text surrounding it.